### PR TITLE
`#[derive(Default)]` for NullPtrError 

### DIFF
--- a/src/comu.rs
+++ b/src/comu.rs
@@ -382,7 +382,7 @@ impl<M, T> Copy for Address<M, T> where M: Mutability
 }
 
 /// [`Address`] cannot be constructed over null pointers.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullPtrError;
 
 impl Display for NullPtrError {

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -23,6 +23,7 @@ the program with a panic due to `SIGPIPE`, and *not* call `process::exit()`.
 
 ```rust,should_panic
 wyz::exit!(3, "Error status: {}", "testing");
+```
 !*/
 
 #![cfg(feature = "std")]


### PR DESCRIPTION
This allows crates that depend on bitvec to not import `wyz::comu` if they wish to manually construct the most common BitPtrError. This allows writing `BitPtrError(Default::default())` if one wants. Alternatively, bitvec can reëxport this type.