### PR TITLE
Drop unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,6 @@ rust-version = "1.40"
 version = "1"
 optional = true
 
-[dependencies.tap]
-version = "1.0.1"
-
-
 [features]
 alloc = []
 default = ["std"]

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -417,7 +417,7 @@ where
 	for<'a> <&'a T as IntoIterator>::Item: Debug,
 {
 	fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-		fmt.debug_list().entries((&self.0).into_iter()).finish()
+		fmt.debug_list().entries(&self.0).finish()
 	}
 }
 


### PR DESCRIPTION
- drop dependency on tap - it's not actually used
- .entries will call into_iter() on its own - no need to do that
